### PR TITLE
Fix the issue when the WebSite og:image format is not supported by iOS, for this case, using the SDWebIamge decoding system instead

### DIFF
--- a/SDWebImageLinkPlugin/Classes/SDImageLinkLoader.m
+++ b/SDWebImageLinkPlugin/Classes/SDImageLinkLoader.m
@@ -118,7 +118,7 @@
         }
         imageProvider = iconProvider;
     }
-    if (requestData) {
+    if (requestData || ![imageProvider canLoadObjectOfClass:UIImage.class]) {
         // Request the image data and decode
         [self fetchImageDataWithProvider:imageProvider metadata:metadata operation:operation url:url options:options context:context progress:progressBlock completed:completedBlock];
     } else {


### PR DESCRIPTION
Test Site: 
https://www.gstatic.com/webp/gallery/1.webp

During test, Seems this is not a issue because LinkPresentation already filter this case ?